### PR TITLE
Python 3.7: Handle the context argument to call_soon

### DIFF
--- a/tests/test_aiowsgi.py
+++ b/tests/test_aiowsgi.py
@@ -83,8 +83,11 @@ class Loop(asyncio.get_event_loop().__class__):
     def create_unix_server(self, *args, **kwargs):
         pass
 
-    def call_soon(self, callback, *args):
-        callback(*args)
+    def call_soon(self, callback, *args, context=None):
+        if context:
+            context.run(callback, *args)
+        else:
+            callback(*args)
 
     def run_forever(self):
         pass


### PR DESCRIPTION
Added in Python 3.7, see PEP 567